### PR TITLE
Use GET requests when checking round status

### DIFF
--- a/gameplay.js
+++ b/gameplay.js
@@ -161,13 +161,14 @@ function isRoundFinished() {
             }
 		}
 	};
-	xhttp.open("POST", "serverside/check-if-round-finished.php", true);
+    xhttp.open("GET", "serverside/check-if-round-finished.php?gid=" + gid + "&round=" + round, true);
+    //xhttp.open("GET", "serverside/lobby-pulse.php?gid=" + gid, true);
     xhttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-	
-	var jsonBody = {};
-    jsonBody["gid"] = gid;
-    jsonBody["round"] = round;
-    xhttp.send(JSON.stringify(jsonBody));
+	xhttp.send()
+	// var jsonBody = {};
+    // jsonBody["gid"] = gid;
+    // jsonBody["round"] = round;
+    // xhttp.send(JSON.stringify(jsonBody));
     
     // If we got this far without redirecting, then either the round wasn't done or there was an error
     // Sleep for 5 seconds and then try again.

--- a/gameplay.js
+++ b/gameplay.js
@@ -162,14 +162,8 @@ function isRoundFinished() {
 		}
 	};
     xhttp.open("GET", "serverside/check-if-round-finished.php?gid=" + gid + "&round=" + round, true);
-    //xhttp.open("GET", "serverside/lobby-pulse.php?gid=" + gid, true);
     xhttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-	xhttp.send()
-	// var jsonBody = {};
-    // jsonBody["gid"] = gid;
-    // jsonBody["round"] = round;
-    // xhttp.send(JSON.stringify(jsonBody));
-    
+
     // If we got this far without redirecting, then either the round wasn't done or there was an error
     // Sleep for 5 seconds and then try again.
     setTimeout(isRoundFinished, 5000);

--- a/serverside/check-if-round-finished.php
+++ b/serverside/check-if-round-finished.php
@@ -1,10 +1,12 @@
 <?php
 
-$request_body = file_get_contents('php://input');
+// $request_body = file_get_contents('php://input');
 
 include("open-database-connection.php");
-$gameID = mysqli_real_escape_string($link, json_decode($request_body,true)["gid"]);
-$round = mysqli_real_escape_string($link, json_decode($request_body,true)["round"]);
+$gameID = mysqli_real_escape_string($link, $_GET["gid"]);
+$round = mysqli_real_escape_string($link, $_GET["round"]);
+// $gameID = mysqli_real_escape_string($link, json_decode($request_body,true)["gid"]);
+// $round = mysqli_real_escape_string($link, json_decode($request_body,true)["round"]);
 
 // Ping the database to check if all players are finished for this round
 $result = mysqli_query($link, "SELECT Status FROM roundstatus WHERE GameID = '".$gameID . "' AND Round = ".$round);

--- a/serverside/check-if-round-finished.php
+++ b/serverside/check-if-round-finished.php
@@ -1,12 +1,8 @@
 <?php
 
-// $request_body = file_get_contents('php://input');
-
 include("open-database-connection.php");
 $gameID = mysqli_real_escape_string($link, $_GET["gid"]);
 $round = mysqli_real_escape_string($link, $_GET["round"]);
-// $gameID = mysqli_real_escape_string($link, json_decode($request_body,true)["gid"]);
-// $round = mysqli_real_escape_string($link, json_decode($request_body,true)["round"]);
 
 // Ping the database to check if all players are finished for this round
 $result = mysqli_query($link, "SELECT Status FROM roundstatus WHERE GameID = '".$gameID . "' AND Round = ".$round);


### PR DESCRIPTION
This seems to resolve the issue with the database/server timing out when large numbers of players are checking round status while waiting for other players to submit.  I know Greg said we should use POST requests for security reasons, but I guess the server has some limitations?

This does not necessarily completely finish it.  I got to Round 7 in a 20-player game, and then the server started timing out. Then it recovered, but somehow it got messed up.  I think my phone might have been the culprit. I may have accidentally submitted something weird and messed up the triggers...?  But at any rate, this is a far better outcome than we had in the past, so let's go with it.