### PR TITLE
Make it so you can draw single dots

### DIFF
--- a/gameplay-canvas.js
+++ b/gameplay-canvas.js
@@ -97,10 +97,8 @@ function drawEnd(mouseEvent) {
 	pos = getXYPos(mouseEvent);
 	if (pos.x > 0 && pos.x < canvas.width && pos.y > 0 && pos.y < canvas.height) {
 		canvasContext.lineTo(pos.x, pos.y);
+		canvasContext.stroke();
 	}
-
-	//Finish the current line
-	//canvasContext.stroke();
 
 	//Completely stop all drawing states
 	draggedOut = false;


### PR DESCRIPTION
I finally figured out what Jacob was talking about. In order to complete a line, including a zero-length line, you need to add the canvasContext.stroke() call. The problem before was that it was outside the if statement, so changing tools would cause random dots to get drawn on the canvas.  The cure for all our problems is to put this inside the if statement so it only completes the line when the mouse position is still within the canvas.