### PR TITLE
Make text input not show history for auto-complete

### DIFF
--- a/gameplay.php
+++ b/gameplay.php
@@ -49,7 +49,7 @@ include("serverside/get-time-limit.php");
 			<p id="timer"></p>
 			<div id="textInput">
 				<!--Inputs for the writing phase-->
-				<input type="text" id="textInputBox" maxlength=<?php echo '"' . $maxTextInputLength . '"'; ?>></input>
+				<input type="text" autocomplete="off" id="textInputBox" maxlength=<?php echo '"' . $maxTextInputLength . '"'; ?>></input>
 			</div>
 			<div id="drawingInput">
 				<!--Inputs for the drawing phase-->


### PR DESCRIPTION
The auto-complete list is annoying and gets in the way of the drawing canvas and isn't relevant/helpful for this game anyway. Make it not show auto-complete suggestions.

Resolves https://github.com/melindamorang/blowyourfaceoff/issues/60