### PR TITLE
Fix auto-injection of inputs when time runs out

### DIFF
--- a/gameplay.js
+++ b/gameplay.js
@@ -266,6 +266,7 @@ function checkForPriorSubmission() {
     var xhttp = new XMLHttpRequest();
     xhttp.onreadystatechange = function() {
         if (this.readyState == 4 && this.status == 200) {
+            console.debug(xhttp.responseText);
             if (xhttp.responseText == "Bad request") {
                 // Something bad happened.  Just fill in dummy values and proceed.
                 console.debug("Unable to check if data already submitted.");
@@ -274,7 +275,7 @@ function checkForPriorSubmission() {
             }
             else {
                 // Only fill in dummy values if the database had nothing in it already.
-                var numNulls = int(xhttp.responseText);
+                var numNulls = parseInt(xhttp.responseText);
                 if (numNulls == 0) {
                     // Somehow values were already in the database. Don't submit anything, just
                     // use what was already there and proceed.

--- a/serverside/is-round-data-submitted.php
+++ b/serverside/is-round-data-submitted.php
@@ -8,12 +8,9 @@ $gameID = mysqli_real_escape_string($link, $_GET["gid"]);
 $player = mysqli_real_escape_string($link, $_GET["name"]);  // current player
 $round = mysqli_real_escape_string($link, $_GET["round"]);  // current round
 
-$result = mysqli_query($link, "SELECT COUNT(IFNULL(ImgRef)) ImgRef AS num FROM game_data WHERE GameID = '".$gameID."' AND Round = ".strval(intval($round))." AND StackOwner = '".$player."' AND ImgRef IS NULL");
+$num = null;
+$result = mysqli_query($link, "SELECT COUNT(IFNULL(ImgRef)) ImgRef AS num FROM game_data WHERE GameID = '".$gameID."' AND `Round` = ".strval(intval($round))." AND StackOwner = '".$player."' AND ImgRef IS NULL");
 include("close-database-connection.php");
-
-// Otherwise, continue the game and start the next round
-$row = mysqli_fetch_assoc($result);
-$numNulls = $row[0];
-echo $numNulls;
+echo $result
 
 ?>


### PR DESCRIPTION
This never worked.  Fix it.

I could not figure out what problem caused the misordering described here: https://github.com/melindamorang/blowyourfaceoff/issues/70

I think the changes I made to prevent auto-injection of data if the user has already submitted something from a different tab may at least alleviate the problem for the most part, now that it actually works with this check-in.  I honestly don't know what I did the other day since it was entirely broken anyway.