### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@
 
 serverside/error_log
 
-serverside/open-database-connection.php
-
 .DS_Store
+
+serverside/local-database-variables.php

--- a/serverside/create-gameplay-tables.php
+++ b/serverside/create-gameplay-tables.php
@@ -44,9 +44,8 @@ if ($numPlayers < $minPlayers || $numPlayers > $maxPlayers) {
         }
     }
     mysqli_query($link,$dataSQL);
-
-    include("close-database-connection.php");
-
     echo "Game Started";
 }
+
+include("close-database-connection.php");
 ?>

--- a/serverside/open-database-connection.php
+++ b/serverside/open-database-connection.php
@@ -1,9 +1,28 @@
 <?php
 
+// These variables must be defined with valid values for your database
+// in order for the program to run. You can change the values here if
+// desired. However, a better option is to add a file in the serverside
+// folder called local-database-variables.php and define the variables
+// there. If that file exists, the variable values in that file will
+// override the values here. The local-database-variables.php file is
+// untracked by the git repo, so you can keep your database info locally,
+// change it as needed, and not risk accidentally checking it in.
 $servername = "";
 $username = "";
 $password = "";
 $database = "";
+// Import local database connection info from the local-database-variables.php
+// file if it exists to override the defaults above.
+// Because this open-database-connection.php file may be imported into files
+// in the serverside folder or its parent directory, we need to check both
+// paths for the existence of the local-database-variables.php file.
+$db_local_config = "local-database-variables.php";
+if (file_exists($db_local_config)) include($db_local_config);
+else {
+    $db_local_config = "serverside/local-database-variables.php";
+    if (file_exists($db_local_config)) include($db_local_config);
+}
 
 // Create connection
 $link = mysqli_connect($servername, $username, $password, $database);


### PR DESCRIPTION
This PR fixes the problems we were having with the .gitignore file and the database connection variables in open-database-connection.php.

First of all, open-database-connection.php is no longer in .gitignore, since putting it there did not accomplish what we were trying to accomplish.

Next, open-database-connection.php includes a definition for the database connection variables, but has them set to an empty string:
```php
$servername = "";
$username = "";
$password = "";
$database = "";
```
This way they are present in a way that makes it clear to a developer that they need to set these values, but our own database connection info is concealed.

Finally, open-database-connection.php looks to see if a file called local-database-variables.php exists. If it does, it includes the file.  The intention is that this other file can include your own definition for the database connection variables, and those will override the defaults in the open-database-connection.php file.  The local-database-variables.php file is now in .gitignore and is not tracked by the repo at all, so you can create your own file and put it in your repo folder without it ever interfering with the repo itself and without risk of it accidentally getting checked in.  It also means I can put the file on the server and not have it get overwritten or destroyed when I deploy changes coming from github.

So, instructions for what to do after this branch gets checked in:
- Clone the repo.
- Add a file to the serverside folder called local-database-variables.php.
- In your copy of local-database-variables.php, put this content:
```php
<?php
$servername = "Your servername";
$username = "Your username";
$password = "Your password";
$database = "Your database name";
?>
```
- Everything should just magically work.
- Your local-database-variables.php will not show up in your git client as an uncommitted change.