### PR TITLE
Don't allow certain problematic characters in names

### DIFF
--- a/pregame.js
+++ b/pregame.js
@@ -57,11 +57,26 @@ function showPriorGameEntry() {
 	showHideElement(priorGameArea, true);
 }
 
+function validateName(name) {
+	badChars = ["&", "=", "?", "/", "%", "#"];
+	if (name === "") {
+		addError("Enter a valid name.");
+		return false;
+	}
+	for (i = 0; i < badChars.length; i++) {
+		if (name.includes(badChars[i])) {
+			addError(`Do not use '${badChars[i]}' in your name.`);
+			return false;
+		}
+	}
+	return true;
+}
+
 // Get the player name from the input control
 function getPlayerName() {
 	var name = nameEdit.value;
-	if (name === "") addError("Enter a valid name.");
-	return name;
+	if (validateName(name)) return name;
+	else return false;
 }
 
 // Get the time limit from the input control and return the value in seconds
@@ -90,7 +105,7 @@ function tryJoin() {
 		return;
 	}
 	var name = getPlayerName();
-	if (name === "") return;
+	if (name === false) return;
 
 	var xhttp = new XMLHttpRequest();
 	xhttp.onreadystatechange = function() {
@@ -129,7 +144,7 @@ function tryJoin() {
 
 function startHost() {
 	var name = getPlayerName();
-	if (name === "") return;
+	if (name === false) return;
 
 	var timeLimitSeconds = getTimeLimit();
 	if (timeLimitSeconds == "invalid") return;

--- a/serverside/get-player-lineup.php
+++ b/serverside/get-player-lineup.php
@@ -11,13 +11,13 @@ include("close-database-connection.php");
 
 $nameList = array();
 while($row = mysqli_fetch_assoc($result)){
-    $nameList[] = $row["Player"];
+    $nameList[] = htmlspecialchars($row["Player"]);
 }
 $numPlayers = count($nameList);
 // Figure out the previous player and next player based on player array indexing
 $currentPlayerIdx = array_search($name, $nameList);
 $nextPlayerIdx = getValidIndex($currentPlayerIdx + 1, $numPlayers);
 $previousPlayerIdx = getValidIndex($currentPlayerIdx - 1, $numPlayers);
-$nextPlayer = htmlspecialchars($nameList[$nextPlayerIdx]);
-$previousPlayer = htmlspecialchars($nameList[$previousPlayerIdx]);
+$nextPlayer = $nameList[$nextPlayerIdx];
+$previousPlayer = $nameList[$previousPlayerIdx];
 ?>


### PR DESCRIPTION
We ran into a problem today with someone using an &. There is probably a way to get around this and other characters reserved for URLs, but it seemed harder than just forbidding them to use these characters.