### PR TITLE
Show message and confirmation button if round times out with no input

### DIFF
--- a/gameplay.js
+++ b/gameplay.js
@@ -30,11 +30,13 @@ document.addEventListener('DOMContentLoaded', function () {
     textInputBox = document.getElementById("textInputBox");
     canvas = document.getElementById("drawingCanvas");
     waitMessage = document.getElementById("waitMessage");
+    timeoutAlert = document.getElementById("timeoutAlert");
     instructionMsg = document.getElementById("instructions");
     timer = document.getElementById("timer");
 
-    // Always hide the waitMessage when the page first loads
+    // Always hide the waitMessage and timeoutAlert when the page first loads
     showHideElement(waitMessage, false);
+    showHideElement(timeoutAlert, false);
 
     // For the first round only, hide the display zone because there is
     // no prior content to display.
@@ -250,19 +252,32 @@ function runTimer() {
             timer.innerHTML = "Time's up! Moving on.";
 
             if (mode == "writing") {
-                if (textInputBox.value === "") checkForPriorSubmission()
+                if (textInputBox.value === "") {
+                    showHideElement(timeoutAlert, true);
+                    showHideElement(gameplayArea, false);
+                }
                 else submit();
             } else {
-                if (isCanvasBlank())  checkForPriorSubmission()
+                if (isCanvasBlank()) {
+                    showHideElement(timeoutAlert, true);
+                    showHideElement(gameplayArea, false);
+                }
                 else submit();
             }
         }
     }, 1000);
 }
 
-function checkForPriorSubmission() {
-    // In the rare case when the timer runs out and the input is empty,
-    // check to make sure data wasn't already submitted in some other way.
+function imStillHere() {
+    // This function gets called when the round times out and the user has entered nothing, they see the message
+    // asking if they're still playing, and they click the "I'm stil here!" button to confirm they are still playing in this tab.
+
+    // Hide the timeout alert and show the wait message temporarily
+    showHideElement(timeoutAlert, false);
+    showHideElement(waitMessage, true);
+
+    // Fill in dummy values so the game can proceed.
+    // First, check to make sure data wasn't already submitted in some other way.
     // This shouldn't happen, but it could if a player switched devices mid-game and
     // left it open on another device or otherwise did something weird.
     var xhttp = new XMLHttpRequest();

--- a/gameplay.php
+++ b/gameplay.php
@@ -30,6 +30,13 @@ include("serverside/get-time-limit.php");
 	<!--The actual content!-->
 	<?php include("snippets/banner.html"); ?>
 	<p id="waitMessage" hidden>Please wait until the other players have finished the round.</p>
+	<div id="timeoutAlert" hidden>
+		<!--This zone is for a special message and confirmation button if the player's time runs out and they haven't entered anything.-->
+		<h2>Are you still here?</h2>
+		<p>We noticed that your time ran out, and you didn't enter anything. If you're no longer playing, please close this browser tab or 
+			<a href="index.php">return to the homepage</a>.</p>
+			<button onclick="imStillHere()">I'm still here!</button>
+	</div>
 	<div id="gameplayArea">
 		<!--This zone encompasses the entire gameplay area, both display and input.-->
 		<p>Round <?php echo $round; ?></p>

--- a/gameplay.php
+++ b/gameplay.php
@@ -33,8 +33,8 @@ include("serverside/get-time-limit.php");
 	<div id="timeoutAlert" hidden>
 		<!--This zone is for a special message and confirmation button if the player's time runs out and they haven't entered anything.-->
 		<h2>Are you still here?</h2>
-		<p>We noticed that your time ran out, and you didn't enter anything. If you're no longer playing, please close this browser tab or 
-			<a href="index.php">return to the homepage</a>.</p>
+		<p>We noticed that your time ran out, and you didn't enter anything. If you're no longer playing or have switched to a different browser tab
+			or device, please close this browser tab or <a href="index.php">return to the homepage</a>.</p>
 			<button onclick="imStillHere()">I'm still here!</button>
 	</div>
 	<div id="gameplayArea">


### PR DESCRIPTION
If the timer runs out and the user has entered nothing, display a message on the page asking if the player is still there. To proceed, they have to click a button proving they are still paying attention to the tab. This prevents problems with multiple simultaneously open tabs submitting things at different times and overwriting each other. Note that it will also pause the game forever if the player has legitimately left, but if they did that, the game wouldn't be very fun anyway.

I initially tried using a Javascript confirm() alert, but I didn't like it because if you switch tabs, it goes away, and it also doesn't show in a non-active tab at all.  This homemade html alert seems more practical for the current purposes.

Resolves (hopefully) https://github.com/melindamorang/blowyourfaceoff/issues/84