### PR TITLE
Add missing htmlspecialchars in endgame links

### DIFF
--- a/endgame.php
+++ b/endgame.php
@@ -33,7 +33,7 @@ include("serverside/close-database-connection.php");
   <p>View another player's stack:</p>
   <ul><?php
       while ($row = mysqli_fetch_assoc($result1)) {
-        $url = "./endgame.php?gid=" . $gidQuery . "&name=" . $row["Player"];
+        $url = "./endgame.php?gid=" . $gidQuery . "&name=" . htmlspecialchars($row["Player"]);
         echo '<li><a href="' . $url . '">' . htmlspecialchars($row["Player"]) . "</a></li>";
       }
       ?>


### PR DESCRIPTION
This fixes the problem with the link URL we encountered for a player whose name was `It's like Vegas but with an "M".`

Resolves https://github.com/melindamorang/blowyourfaceoff/issues/88