### PR TITLE
Fix stray lines

### DIFF
--- a/gameplay-canvas.js
+++ b/gameplay-canvas.js
@@ -113,10 +113,12 @@ function drawEnd(mouseEvent) {
 	}
 
 	//If the mouse is still on the canvas, make one last line
-	pos = getXYPos(mouseEvent);
-	if (pos.x > 0 && pos.x < canvas.width && pos.y > 0 && pos.y < canvas.height) {
-		canvasContext.lineTo(pos.x, pos.y);
-		canvasContext.stroke();
+	if (isDrawing) {
+		pos = getXYPos(mouseEvent);
+		if (pos.x > 0 && pos.x < canvas.width && pos.y > 0 && pos.y < canvas.height) {
+			canvasContext.lineTo(pos.x, pos.y);
+			canvasContext.stroke();
+		}
 	}
 
 	//Completely stop all drawing states

--- a/gameplay-canvas.js
+++ b/gameplay-canvas.js
@@ -68,6 +68,8 @@ function drawStart(mouseEvent) {
 		return;
 	}
 
+	console.debug("drawStart. mouseEvent: " + mouseEvent.type)
+
 	if (mouseEvent.type == "touchstart") {
 		mouseEvent = mouseEvent.touches[0];
 		if (isIOS) disableScroll();
@@ -87,6 +89,7 @@ function drawStart(mouseEvent) {
 function drawTick(mouseEvent) {
 	//Only draw if we are in a drawing state
 	if (isDrawing) {
+		console.debug("drawTick. mouseEvent: " + mouseEvent.type)
 
 		//If this is a touchscreen event, use the primary touch for drawing
 		if (mouseEvent.type == "touchmove") {
@@ -106,6 +109,7 @@ function drawTick(mouseEvent) {
 }
 
 function drawEnd(mouseEvent) {
+	console.debug("drawEnd. mouseEvent: " + mouseEvent.type)
 	//If this is a touchscreen event, look at the primary touch
 	if (mouseEvent.type == "touchend" || mouseEvent.type == "touchcancel") {
 		mouseEvent = mouseEvent.touches[0];
@@ -126,7 +130,8 @@ function drawEnd(mouseEvent) {
 	isDrawing = false;
 }
 
-function drawLeave() {
+function drawLeave(mouseEvent) {
+	console.debug("drawLeave. mouseEvent: " + mouseEvent.type)
 	//If we were drawing when we dragged out, we want that to continue when we drag back in
 	draggedOut = isDrawing;
 


### PR DESCRIPTION
This is a minimal change that incorporates a tiny, unrelated part of Jacob's fix for tablets. I was working on something similar as well.  Basically, if you click down on the mouse outside the canvas, drag over the canvas, and let go, it will auto-complete a big straight line from wherever you last stopped drawing before you left the canvas in the first place. This is obviously undesirable. This change does not fix the pen issue, and I also confirmed it does not break dots on iPhones.

I also added logging to each of the drawing methods so it's easier to tell what's going on when debugging.