### PR TITLE
Created class toggle for textarea

### DIFF
--- a/gameplay.js
+++ b/gameplay.js
@@ -238,7 +238,10 @@ function textSize() {
 	var gameStr = ta.value;
 	var lg = gameStr.length;
 	if (lg > 180) {
-		ta.style = "font-size:1.6em;";
+		ta.className = "lgClass";
+	}
+	else if (lg <= 180) {
+		ta.className = "startClass";
 	}
 }
 

--- a/style.css
+++ b/style.css
@@ -177,9 +177,15 @@ button:checked, button:focus {
 	border: none;
 	border-radius: 1em;
 	margin: 1em 0 0 0;
-	font-size: 2em;
 	text-align: center;
 	color: #000000;
+}
+#textInputBox.lgClass {
+	font-size: 1.6em;
+}
+
+#textInputBox.startClass {
+	font-size: 2em;
 }
 #inputZone #textInputBox:focus {
 	color: #000000;


### PR DESCRIPTION
Textarea now changes class name instead of style. Size reduces at 180+ and enlarges at 179-.

There's probably an easier way to toggle this, but this works and I will note on the issue to update with slicker code.