### PR TITLE
Don't update touchend mouse event if it's undefined

### DIFF
--- a/gameplay-canvas.js
+++ b/gameplay-canvas.js
@@ -115,7 +115,8 @@ function drawEnd(mouseEvent) {
 	console.debug("drawEnd. mouseEvent: " + mouseEvent.type)
 	//If this is a touchscreen event, look at the primary touch
 	if (mouseEvent.type == "touchend" || mouseEvent.type == "touchcancel") {
-		mouseEvent = mouseEvent.touches[0];
+		updatedMouseEvent = mouseEvent.touches[0];
+		if (updatedMouseEvent !== undefined) mouseEvent = updatedMouseEvent;
 		if (isIOS) enableScroll();
 	}
 


### PR DESCRIPTION
While working on the Undo enhancement, I finally set it up so I could access my PC's localhost from my Android phone and debug what was happening on my phone using my PC. Woohoo!  I discovered an error in the drawEnd() function:

```
gameplay-canvas.js:156 Uncaught TypeError: Cannot read property 'clientX' of undefined
    at getXYPos (gameplay-canvas.js:156)
    at HTMLDocument.drawEnd (gameplay-canvas.js:124)
```

The issue is here:
```javascript
//If this is a touchscreen event, look at the primary touch
	if (mouseEvent.type == "touchend" || mouseEvent.type == "touchcancel") {
		mouseEvent = mouseEvent.touches[0];
		if (isIOS) enableScroll();
	}
```
`mouseEvent.touches[0]` is undefined, and everything after that fails, even though it still sort of works.

I updated it so it only changes the mouseEvent in the case where `mouseEvent.touches[0]` is not undefined. This fixes the error on my Android, makes undo actually work on my Android (separate branch), and may fix some other things we don't know about.

This might fix the drawing pen issue...? (https://github.com/melindamorang/blowyourfaceoff/issues/94) I am not terribly hopeful, but it's worth a try.