### PR TITLE
Don't allow players to use < and > in names

### DIFF
--- a/pregame.js
+++ b/pregame.js
@@ -58,7 +58,7 @@ function showPriorGameEntry() {
 }
 
 function validateName(name) {
-	badChars = ["&", "=", "?", "/", "%", "#"];
+	badChars = ["&", "=", "?", "/", "%", "#", ">", "<"];
 	if (name === "") {
 		addError("Enter a valid name.");
 		return false;


### PR DESCRIPTION
There's probably a way we could support this, but, really, the universe isn't going to explode if players can't name themselves things with < and >. Get over it, ya'll.

Fixes https://github.com/melindamorang/blowyourfaceoff/issues/100