### PR TITLE
Show confirmation pop-up when leaving gameplay

### DIFF
--- a/js/gameplay.js
+++ b/js/gameplay.js
@@ -4,6 +4,17 @@
 // Canvas-specific control logic is in gameplay-canvas.js.
 // HTML file must import shared-functions.js for this file to work.
 
+// Show an alert if the user tries to leave, reload, or close the page during gameplay.
+// The pop-up gives the browser's default message with a continue or cancel button.
+// According to the internet, there is no way to customize the message in modern browsers.
+// Chrome says "Leave site? The changes you made might not be saved." Better than nothing
+// and probably suffient to prevent people from accidentally ruining the game even if it
+// doesn't explicitly say "Leaving this page will ruin the game."
+window.addEventListener('beforeunload', function (e) {
+    e.preventDefault();
+    e.returnValue = '';
+});
+
 // When the page first loads, show and hide content depending on round
 document.addEventListener('DOMContentLoaded', function () {
     // Retrieve page elements and store them as global variables


### PR DESCRIPTION
Show the browser's default "leave page" confirmation dialog if the user tries to close, reload, or navigate away from the gameplay page since that will ruin the game.

Yo @sgriffin231 Does this look like the right approach to you? It seems to work, and it's what the Internet said to do, but I don't speak Javascript very well...