### PR TITLE
Make the gameplay input zone not selectable

### DIFF
--- a/style.css
+++ b/style.css
@@ -212,6 +212,11 @@ button:checked, button:focus {
 	text-align: center;
 	width: 400px;
 }
+#inputZone {
+	-webkit-user-select: none; /* Safari */
+	-ms-user-select: none; /* IE 10 and IE 11 */
+	user-select: none; /* Standard syntax */
+}
 #inputZone #textInputBox {
 	width: 460px;
 	height: 260px;


### PR DESCRIPTION
I think this will prevent weird drawing issues that occur when the canvas is inadvertently selected.

I tried to make only the canvas not selectable, but that didn't seem to work and I still had problems. This change here works better, although if the user selects the text above the canvas, you can still get in a weird selecty drag-drop state. But this seems to be a net improvement.

Sarah does this seem sensible?

Addresses https://github.com/melindamorang/blowyourfaceoff/issues/125