### PR TITLE
Trim leading and trailing whitespace in player names

### DIFF
--- a/js/pregame.js
+++ b/js/pregame.js
@@ -74,7 +74,7 @@ function validateName(name) {
 
 // Get the player name from the input control
 function getPlayerName() {
-	var name = nameEdit.value;
+	var name = nameEdit.value.trim();
 	if (validateName(name)) return name;
 	else return false;
 }


### PR DESCRIPTION
Fixes https://github.com/melindamorang/blowyourfaceoff/issues/130

I'm not really sure why there was funky behavior, but I think it's because the trailing whitespace got magically stripped out when it was sent to the database, but it wasn't stripped out in the html where the name is preserved, leaving them out of sync. Just trimming leading and trailing whitespace up front fixes the issue.