### PR TITLE
Caching - make page at least not broken

### DIFF
--- a/js/search-games.js
+++ b/js/search-games.js
@@ -1,0 +1,31 @@
+// Functions for searching old games
+
+// When the page first loads, show and hide content depending on round
+document.addEventListener('DOMContentLoaded', function () {
+    // Retrieve page elements and store them as global variables
+    // (This is done by not declaring them as var. Javascript is sneaky.)
+    searchText = document.getElementById("searchTextValue").value;
+    console.debug(searchText);
+    searchResultsDisplay = document.getElementById("searchResults");
+
+    // Search the database using the search string entered by the user
+    searchByText();
+
+});
+
+// Search the game database by the designated text string and return html to insert
+function searchByText() {
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            // Display the results in the display area
+            searchResultsDisplay.innerHTML = xhttp.responseText;
+        }
+        else {
+            searchResultsDisplay.innerHTML = "<p>Error retrieving search results from game database.</p>";
+        }
+    };
+    xhttp.open("GET", "serverside/search-stack-text.php?searchText=" + searchText, true);
+    xhttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+    xhttp.send();
+};

--- a/load.php
+++ b/load.php
@@ -23,6 +23,9 @@ if ($pagename) {
 	else if ($pagename == "Lobby") {
 		$headscripts = '<script src="js/lobby.js"></script>';
 	}
+	else if ($pagename == "Search Stacks") {
+		$headscripts = '<script src="js/search-games.js"></script>';
+	}
 	else $headscripts = '';
 }
 ?>

--- a/searchText.php
+++ b/searchText.php
@@ -5,12 +5,13 @@ $searchTextDisplay = htmlspecialchars($_GET["searchText"]);
 <?php $pagename = "Search Stacks" ?>
 <?php include("header.php"); ?>
 
+<!--Hidden controls to hold variables that need to be passed around-->
+<input type="text" id="searchTextValue" hidden value="<?php echo $searchTextDisplay; ?>">
+
 	<div class="main-content">
 		<h2>Showing results for: <span id="searchText"><?php echo $searchTextDisplay; ?></span></h2>
 
-		<div id="searchResults">
-			<?php include("serverside/search-stack-text.php"); ?>
-		</div>
+		<div id="searchResults"></div>
 
 		<ul class="endStackMenu">
 			<li><a class="button" onclick="window.scrollTo(0,0)">Return to top</a></li>

--- a/serverside/search-stack-text.php
+++ b/serverside/search-stack-text.php
@@ -9,7 +9,7 @@ $result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data 
 include("close-database-connection.php");
 
 if(mysqli_num_rows($result)==0){
-    echo "<p>No results found.<p>";
+    echo "<p>No results found for \"" . $searchText . "\".<p>";
 } else {
 
     // For each result, construct a URL to its associated stack and create an li with the stack text


### PR DESCRIPTION
There's still something odd going on with searching the database by text string, but this change at least makes the search results page not broken.

I refactored searchText.php to use a Javascript XMLHttpRequest instead of doing all directly in the page's php.  This at least allows for better error handling.  The page now has valid html and the footer is back.

The next step is to figure out what about that request is not working, but at least this fixes the page.