### PR TITLE
Make text search much faster

### DIFF
--- a/serverside/search-stack-text.php
+++ b/serverside/search-stack-text.php
@@ -6,7 +6,7 @@ $searchText = mysqli_real_escape_string($link, $_GET["searchText"]);
 // DISTINCT ON (GameID, StackOwner) is not supported on our flavor of SQL.
 // Just grab them all and deal with it in post-processing.
 //$result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE ImgRef LIKE '%" . $searchText . "%' ORDER BY GameID, StackOwner");
-$result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE MATCH(ImgRef) AGAINST ('" . $searchText . "' IN NATURAL LANGUAGE MODE)");
+$result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE (Round % 2) = 0 AND MATCH(ImgRef) AGAINST ('" . $searchText . "' IN NATURAL LANGUAGE MODE)");
 
 if ($result) {
     if(mysqli_num_rows($result)==0){

--- a/serverside/search-stack-text.php
+++ b/serverside/search-stack-text.php
@@ -5,7 +5,9 @@ $searchText = mysqli_real_escape_string($link, $_GET["searchText"]);
 // Can't use DISTINCT because we only want it to apply to GameID/StackOwner and not ImgRef.
 // DISTINCT ON (GameID, StackOwner) is not supported on our flavor of SQL.
 // Just grab them all and deal with it in post-processing.
-$result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE ImgRef LIKE '%" . $searchText . "%' ORDER BY GameID, StackOwner");
+//$result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE ImgRef LIKE '%" . $searchText . "%' ORDER BY GameID, StackOwner");
+$result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE MATCH(ImgRef) AGAINST ('" . $searchText . "' IN NATURAL LANGUAGE MODE)");
+include("close-database-connection.php");
 
 if ($result) {
     if(mysqli_num_rows($result)==0){
@@ -52,7 +54,5 @@ if ($result) {
 else {
     echo "<p>Error querying database: " . mysqli_error($link) . "</p>";
 }
-
-include("close-database-connection.php");
 
 ?>

--- a/serverside/search-stack-text.php
+++ b/serverside/search-stack-text.php
@@ -5,7 +5,6 @@ $searchText = mysqli_real_escape_string($link, $_GET["searchText"]);
 // Can't use DISTINCT because we only want it to apply to GameID/StackOwner and not ImgRef.
 // DISTINCT ON (GameID, StackOwner) is not supported on our flavor of SQL.
 // Just grab them all and deal with it in post-processing.
-//$result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE ImgRef LIKE '%" . $searchText . "%' ORDER BY GameID, StackOwner");
 $result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE (Round % 2) = 0 AND MATCH(ImgRef) AGAINST ('" . $searchText . "' IN NATURAL LANGUAGE MODE)");
 
 if ($result) {

--- a/serverside/search-stack-text.php
+++ b/serverside/search-stack-text.php
@@ -6,7 +6,6 @@ $searchText = mysqli_real_escape_string($link, $_GET["searchText"]);
 // DISTINCT ON (GameID, StackOwner) is not supported on our flavor of SQL.
 // Just grab them all and deal with it in post-processing.
 $result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE ImgRef LIKE '%" . $searchText . "%' ORDER BY GameID, StackOwner");
-include("close-database-connection.php");
 
 if ($result) {
     if(mysqli_num_rows($result)==0){
@@ -53,5 +52,7 @@ if ($result) {
 else {
     echo "<p>Error querying database: " . mysqli_error($link) . "</p>";
 }
+
+include("close-database-connection.php");
 
 ?>

--- a/serverside/search-stack-text.php
+++ b/serverside/search-stack-text.php
@@ -7,7 +7,6 @@ $searchText = mysqli_real_escape_string($link, $_GET["searchText"]);
 // Just grab them all and deal with it in post-processing.
 //$result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE ImgRef LIKE '%" . $searchText . "%' ORDER BY GameID, StackOwner");
 $result = mysqli_query($link, "SELECT GameID, StackOwner, ImgRef FROM game_data WHERE MATCH(ImgRef) AGAINST ('" . $searchText . "' IN NATURAL LANGUAGE MODE)");
-include("close-database-connection.php");
 
 if ($result) {
     if(mysqli_num_rows($result)==0){
@@ -54,5 +53,7 @@ if ($result) {
 else {
     echo "<p>Error querying database: " . mysqli_error($link) . "</p>";
 }
+
+include("close-database-connection.php");
 
 ?>


### PR DESCRIPTION
Thanks for the advice, Jacob and Lui.  Use NATURAL LANGUAGE MODE search and filter out image rows.
(Note: The php issue actually just required setting the site's php version back to 8 and has nothing to do with this PR or the site's code.)